### PR TITLE
Fix keyboard shortcuts in Obsidian and add create/append-anything popups (a/n)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ package-lock.json
 # build
 main.js
 *.js.map
+/styles.css
+/bpmn-*.eot
+/bpmn-*.svg
+/bpmn-*.ttf
+/bpmn-*.woff
+/bpmn-*.woff2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All changes to this plugin are listed here.
 
 - Added the bpmn-js "create/append anything" feature: press `a` to append a new node to the selected element, `n` to create a new node (both open a searchable popup menu)
 
+### Updated
+
+- Bump bpmn-js-token-simulation to 0.39.3: 0.38.x imports the removed default export of ids v3, which breaks the esbuild bundling on a fresh install
+
 ## 7.3.3 (2025-10-06)
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All changes to this plugin are listed here.
 
+## Unreleased
+
+### Fixed
+
+- Keyboard shortcuts (e.g. `e` edit, `r` replace) now work inside Obsidian: the diagram canvas is focused when the mouse enters it, so bpmn-js receives key events
+
+### New
+
+- Added the bpmn-js "create/append anything" feature: press `a` to append a new node to the selected element, `n` to create a new node (both open a searchable popup menu)
+
 ## 7.3.3 (2025-10-06)
 
 ### Updated

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bpmn-js-create-append-anything": "^1.2.0",
     "bpmn-js-properties-panel": "^5.43.0",
     "bpmn-js-sketchy": "^0.7.2",
-    "bpmn-js-token-simulation": "^0.38.1",
+    "bpmn-js-token-simulation": "^0.39.3",
     "diagram-js-grid": "^1.1.0",
     "diagram-js-minimap": "^5.2.0",
     "heatmap-ts": "^0.0.5"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@bpmn-io/properties-panel": "^3.34.0",
     "bpmn-js": "^18.8.0",
     "bpmn-js-color-picker": "^0.7.2",
+    "bpmn-js-create-append-anything": "^1.2.0",
     "bpmn-js-properties-panel": "^5.43.0",
     "bpmn-js-sketchy": "^0.7.2",
     "bpmn-js-token-simulation": "^0.38.1",

--- a/src/bpmnModeler.ts
+++ b/src/bpmnModeler.ts
@@ -10,6 +10,8 @@ import TokenSimulationModule from "bpmn-js-token-simulation";
 import SimulationSupportModule from 'bpmn-js-token-simulation/lib/simulation-support';
 import BpmnColorPickerModule from "bpmn-js-color-picker";
 // @ts-ignore
+import {CreateAppendAnythingModule} from 'bpmn-js-create-append-anything';
+// @ts-ignore
 import gridModule from 'diagram-js-grid';
 import minimapModule from 'diagram-js-minimap';
 import sketchyRendererModule from 'bpmn-js-sketchy';
@@ -67,6 +69,7 @@ export class BpmnModelerView extends TextFileView {
             BpmnPropertiesPanelModule,
             BpmnPropertiesProviderModule,
             BpmnColorPickerModule,
+            CreateAppendAnythingModule,
         ];
         if (this.settings.enable_token_simulator) {
             modules.push(TokenSimulationModule);
@@ -101,6 +104,9 @@ export class BpmnModelerView extends TextFileView {
             },
             additionalModules: modules,
             textRenderer: textRenderer,
+            canvas: {
+                autoFocus: true
+            },
         });
         if (this.settings.force_white_background_by_default) {
             this.bpmnDiv.addClass("bpmn-view-white-background");
@@ -109,6 +115,24 @@ export class BpmnModelerView extends TextFileView {
         const bpmnModeler = this.bpmnModeler;
         const canvas = bpmnModeler.get('canvas');
         const thisRef = this;
+        // bpmn-js binds its keyboard shortcuts (a, n, e, r, h, l, s, ...) to the
+        // canvas SVG element, which only receives key events while focused.
+        // Obsidian keeps focus on its own workspace elements, so the built-in
+        // autoFocus (which requires document.body to be focused) never kicks in.
+        // Focus the canvas when the mouse enters the diagram, unless the user is
+        // typing somewhere else (e.g. the properties panel or a note).
+        this.registerDomEvent(this.bpmnDiv, "mouseenter", function () {
+            const active = document.activeElement;
+            if (active instanceof HTMLElement &&
+                (active.isContentEditable ||
+                    active.tagName === "INPUT" ||
+                    active.tagName === "TEXTAREA" ||
+                    active.tagName === "SELECT")) {
+                return;
+            }
+            // @ts-ignore
+            canvas.focus();
+        });
         this.bpmnModeler.on("commandStack.changed", function () {
             bpmnModeler.saveXML({format: true}).then(function (data: any) {
                 const {xml} = data;

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,7 @@ export default class ObsidianBPMNPlugin extends Plugin {
             }
         });
     }
-    private async renderBPMNBlock(parameters: BpmnNodeParameters, el, ctx) {
+    private async renderBPMNBlock(parameters: BpmnNodeParameters, el: HTMLElement, ctx: MarkdownPostProcessorContext) {
         console.log("Try to render a BPMN");
         try {
             if (parameters.url.startsWith("./")) {


### PR DESCRIPTION
adds the bpmn-js-create-append-anything module, which provides the a (append element) and n (create element) popup menus known from demo.bpmn.io