### PR TITLE
Render embedded BPMN viewers in their embed container

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -76,7 +76,7 @@ export default class ObsidianBPMNPlugin extends Plugin {
                     return;
                 }
                 embed.innerHTML = "";
-                this.renderBPMNBlock(parameters, el, ctx);
+                this.renderBPMNBlock(parameters, embed, ctx);
                 embed.addClass("bpmn-embed");
             });
         });

--- a/tests/embed-render-target.test.mjs
+++ b/tests/embed-render-target.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("embedded BPMN diagrams render inside their embed element", () => {
+    const source = readFileSync(new URL("../src/main.ts", import.meta.url), "utf8");
+    const postProcessor = source.match(
+        /\/\/ Add !\[\[\]\] embedding([\s\S]*?)\/\/ Add icon/
+    );
+
+    assert.ok(postProcessor, "BPMN embed post-processor should be registered");
+    assert.match(
+        postProcessor[1],
+        /this\.renderBPMNBlock\(parameters,\s*embed,\s*ctx\)/,
+        "embedded BPMN viewer should render inside the matched embed element"
+    );
+});


### PR DESCRIPTION
## Summary

- render BPMN wiki-link embeds inside their matched `.internal-embed` container
- add a focused regression test for render-target selection

## Tests

- `OPENSSL_CONF=/dev/null node --test tests/embed-render-target.test.mjs` — passed (1 test) in pinned Node 22 Docker with networking disabled
- `npm run build` — passed in the same pinned, network-disabled verifier; TypeScript no-emit checking and the production esbuild bundle completed

Fixes #184

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1040:start -->
### Verification

[Northset proof-of-pass receipt M-1040](https://northset-oss.github.io/verification-pilot/receipts/M-1040/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1040:end -->
